### PR TITLE
Fixed issue where passing npm.cmd to spawn() caused a Error spawn EIN…

### DIFF
--- a/cli.create-factory.js
+++ b/cli.create-factory.js
@@ -203,7 +203,7 @@ exports.Run = function(params, options, onSuccess){
           if(parseInt(global._NPM_VER[0])>=6) return resolve();
           console.log('ERROR: Please upgrade your NPM version to 6 or higher');
         }
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); }, {shell: true});
     }); })
 
     //Check if supervisor is installed
@@ -214,7 +214,7 @@ exports.Run = function(params, options, onSuccess){
       },undefined,function(err){
         global._FOUND_SUPERVISOR = false;
         resolve();
-      });
+      }, {shell: true});
     }); })
 
     //Ask user to install supervisor
@@ -245,7 +245,7 @@ exports.Run = function(params, options, onSuccess){
       console.log('\r\nInstalling local dependencies');
       xlib.spawn(global._NPM_CMD,['install'],function(code){ resolve(); },function(data){
         console.log(data);
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); }, {shell: true});
     }); })
 
     //Create app.config.js


### PR DESCRIPTION
…VAL. This occurs on latest versions of node where a security patch disallows passing .cmd files to spawn().

Solution: use {shell:true} option for all npm.cmd pass to spawn occurrences.