### PR TITLE
Jsharmony cli shell patch

### DIFF
--- a/cli.create-empty.js
+++ b/cli.create-empty.js
@@ -244,7 +244,7 @@ exports.Run = function(params, options, onSuccess){
           if(parseInt(global._NPM_VER[0])>=3) return resolve();
           console.log('ERROR: Please upgrade your NPM version to 3 or higher');
         }
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); }, {shell: true});
     }); })
 
     //Check if supervisor is installed
@@ -255,7 +255,7 @@ exports.Run = function(params, options, onSuccess){
       },undefined,function(err){
         global._FOUND_SUPERVISOR = false;
         resolve();
-      });
+      }, {shell: true});
     }); })
 
     //Ask user to install supervisor
@@ -284,7 +284,7 @@ exports.Run = function(params, options, onSuccess){
       console.log('\r\nInstalling local dependencies');
       xlib.spawn(global._NPM_CMD,['install'],function(code){ resolve(); },function(data){
         console.log(data);
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); }, {shell: true});
     }); })
 
     //Create app.config.js

--- a/cli.create-factory.js
+++ b/cli.create-factory.js
@@ -203,7 +203,7 @@ exports.Run = function(params, options, onSuccess){
           if(parseInt(global._NPM_VER[0])>=6) return resolve();
           console.log('ERROR: Please upgrade your NPM version to 6 or higher');
         }
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); }, {shell: true});
     }); })
 
     //Check if supervisor is installed
@@ -214,7 +214,7 @@ exports.Run = function(params, options, onSuccess){
       },undefined,function(err){
         global._FOUND_SUPERVISOR = false;
         resolve();
-      });
+      }, {shell: true});
     }); })
 
     //Ask user to install supervisor
@@ -245,7 +245,7 @@ exports.Run = function(params, options, onSuccess){
       console.log('\r\nInstalling local dependencies');
       xlib.spawn(global._NPM_CMD,['install'],function(code){ resolve(); },function(data){
         console.log(data);
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); }, {shell: true});
     }); })
 
     //Create app.config.js

--- a/cli.create-project.js
+++ b/cli.create-project.js
@@ -478,7 +478,7 @@ exports.Run = function(params, options, onSuccess){
           if(parseInt(global._NPM_VER[0])>=6) return resolve();
           console.log('ERROR: Please upgrade your NPM version to 6 or higher');
         }
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); }, {shell: true});
     }); })
 
     //Check if supervisor is installed
@@ -490,7 +490,7 @@ exports.Run = function(params, options, onSuccess){
       },undefined,function(err){
         global._FOUND_SUPERVISOR = false;
         resolve();
-      });
+      }, {shell: true});
     }); })
 
     //Ask user to install supervisor
@@ -523,7 +523,7 @@ exports.Run = function(params, options, onSuccess){
       console.log('\r\nInstalling local dependencies');
       xlib.spawn(global._NPM_CMD,['install'],function(code){ resolve(); },function(data){
         console.log(data);
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM are installed.'); }, {shell: true});
     }); })
 
     //Run dos2unix on executable JS

--- a/cli.create-tutorials.js
+++ b/cli.create-tutorials.js
@@ -160,7 +160,7 @@ exports.Run = function(params, options, onSuccess){
           if(parseInt(global._NPM_VER[0])>=3) return resolve();
           console.log('ERROR: Please upgrade your NPM version to 3 or higher');
         }
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); }, {shell: true});
     }); })
 
     //Run npm install
@@ -168,7 +168,7 @@ exports.Run = function(params, options, onSuccess){
       console.log('\r\nInstalling local dependencies');
       xlib.spawn(global._NPM_CMD,['install'],function(code){ resolve(); },function(data){
         console.log(data);
-      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); });
+      },undefined,function(err){ console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.'); }, {shell: true});
     }); })
 
     //Create app.config.js

--- a/cli.test-install.js
+++ b/cli.test-install.js
@@ -48,7 +48,7 @@ exports.Run = function(params, options, onSuccess){
       },undefined,function(err){
         console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.');
         run_cb(err);
-      });
+      }, {shell: true});
     },
     function(run_cb){
       jshcli_Shared.getModulePath('jsharmony-test', function(err, mpath){
@@ -58,7 +58,7 @@ exports.Run = function(params, options, onSuccess){
         },undefined,function(err){
           console.log('ERROR: Could not find or start '+global._NPM_CMD+'. Check to make sure Node.js and NPM is installed.');
           run_cb(err);
-        });
+        }, {shell: true});
       });
     },
     function(dir_cb){


### PR DESCRIPTION
Fixed issue where passing npm.cmd to spawn() caused a Error spawn EINVAL. This occurs on latest versions of node where a security patch disallows passing .cmd files to spawn().
Solution: use {shell:true} option for all npm.cmd pass to spawn occurrences.